### PR TITLE
fields: simpler updates handling and non-stored fields

### DIFF
--- a/docs/wiki/baseclasses.md
+++ b/docs/wiki/baseclasses.md
@@ -148,15 +148,122 @@ redis = StoredFactory(RedisClient)
 
 
 
-## Data updates
+## Data updates and computed fields
+Sometimes you may need to update any field's value based on some changes, or even re-create or re-initialize other related objects for your instance.
 
-In your instance, you can implement `_attr_updated` to handle attribute updates, but by default, an event of the type `AttributeUpdateEvent` is fired.
+We provide multiple ways for such cases, each of them can be used as needed:
 
-Using events here allow other components to handle events related to your base implementation too.
+- [Single field updates](#single-field-updates)
+- [Computed and non-stored fields](#computed-and-non-stored-fields)
+- [Attributes updates and events](#attributes-updates-and-events)
 
-An example of using `attr_updated` or events to re-create an inner client (redis):
+### Single field updates
 
-Using `_attr_updated`:
+If you need to do an action only when a single field is changed, You can use `on_update` for any field, which should be a callable that takes the instance and new value, see stellar client as an example:
+
+```python
+class Stellar(Client):
+    network = fields.Enum(Network)
+    address = fields.String()
+
+    def secret_updated(self, value):
+        self.address = stellar_sdk.Keypair.from_secret(value).public_key
+
+    secret = fields.String(on_update=secret_updated)
+```
+
+In this code, we set a new value for the address in case the secret is updated.
+
+### Computed and non-stored fields
+
+Sometimes you need a field to be computed from other multiple fields, in such case, you just need to provide a `compute` function which takes current instance and it should return the computed value, see the following example:
+
+```python
+class User(Base):
+    emails = fields.List(fields.String())
+    first_name = fields.String(default="")
+    last_name = fields.String(default="")
+
+    def get_full_name(self):
+        name = self.first_name
+        if self.last_name:
+            name += " " + self.last_name
+        return name
+
+    def get_unique_name(self):
+        return self.full_name.replace(" ", "") + ".user"
+
+    full_name = fields.String(compute=get_full_name)
+    unique_name = fields.String(compute=get_unique_name)
+
+
+users = StoredFactory(User)
+user1 = users.get("test1")
+
+print(user1.full_name)  #=> "ahmed mohamed"
+print(user1.unique_name)  #=> "ahmedmohaed.user"
+
+user1.first_name = "x"
+user1.last_name = "y"
+user1.save()
+```
+
+Note that, when saving the user object with this factory, the computed field will be saved too.
+
+In other cases, you need to create a non-stored computed fields, which also do not need any serialization, but only to be created and used at run-time, this can be done by passing `stored=False` to this field (which is `True` by default):
+
+```python
+class Greeter:
+    def __init__(self, name):
+        self.name = name
+
+    def say(self):
+        print("hello", self.name)
+
+
+class User(Base):
+    first_name = fields.String(default="")
+    last_name = fields.String(default="")
+
+    def get_full_name(self):
+        name = self.first_name
+        if self.last_name:
+            name += " " + self.last_name
+        return name
+
+    full_name = fields.String(compute=get_full_name)
+
+    def get_my_greeter(self):
+            return Greeter(self.full_name)
+
+    my_greeter = fields.Typed(Greeter, stored=False, compute=get_my_greeter)
+    ahmed_greeter = fields.Typed(Greeter, stored=False, default=Greeter("ahmed"))
+
+
+
+users = StoredFactory(User)
+user = users.get("test1")
+
+user.first_name = "abdo"
+user.last_name = "tester"
+user.my_greeter.say()  #=> "hello abdo tester"
+user.ahmed_greeter.say()  => "hello ahmed"
+user.save()
+```
+
+we created two `Typed` fields of `Greeter` class, and used them without any problems, when saving this instance, these fields won't be serialized nor stored.
+
+### Attributes updates and events
+
+A more advanced feature are events and `_attr_updated` method, in any instance, you can override `_attr_updated` to handle attribute updates, also by default, an event of the type `AttributeUpdateEvent` is fired.
+
+Using events can allow other components to handle events related to your base implementation, so it's not needed unless you need other people to know about your changes.
+
+In this way, the instance receives a call or an `AttributeUpdateEvent` for any attribute.
+
+An example of using `attr_updated` or events to re-create an inner client (redis), as the client need to re-created if any of `hostname` or `port` has been changed:
+
+__Using__ `_attr_updated`:
 
 ```python
 class RedisClient(Client):
@@ -176,7 +283,7 @@ class RedisClient(Client):
 
 ```
 
-Or using events (so, others can know of this change too):
+__Or using__ events (so, others can know of this change too):
 
 ```python
 class RedisClientAttributeUpdated(AttributeUpdateEvent):

--- a/docs/wiki/baseclasses.md
+++ b/docs/wiki/baseclasses.md
@@ -149,9 +149,10 @@ redis = StoredFactory(RedisClient)
 
 
 ## Data updates and computed fields
-Sometimes you may need to update any field's value based on some changes, or even re-create or re-initialize other related objects for your instance.
 
-We provide multiple ways for such cases, each of them can be used as needed:
+In your instance, you can handle data updates in many ways, from triggering a handler on single field updates, to event-based system.
+
+The following are three different ways to do it:
 
 - [Single field updates](#single-field-updates)
 - [Computed and non-stored fields](#computed-and-non-stored-fields)

--- a/docs/wiki/baseclasses.md
+++ b/docs/wiki/baseclasses.md
@@ -155,7 +155,7 @@ We provide multiple ways for such cases, each of them can be used as needed:
 
 - [Single field updates](#single-field-updates)
 - [Computed and non-stored fields](#computed-and-non-stored-fields)
-- [Attributes updates and events](#attributes-updates-and-events)
+- [Attribute updates and events](#attribute-updates-and-events)
 
 ### Single field updates
 
@@ -253,7 +253,7 @@ user.save()
 
 we created two `Typed` fields of `Greeter` class, and used them without any problems, when saving this instance, these fields won't be serialized nor stored.
 
-### Attributes updates and events
+### Attribute updates and events
 
 A more advanced feature are events and `_attr_updated` method, in any instance, you can override `_attr_updated` to handle attribute updates, also by default, an event of the type `AttributeUpdateEvent` is fired.
 

--- a/jumpscale/clients/stellar/stellar.py
+++ b/jumpscale/clients/stellar/stellar.py
@@ -63,20 +63,11 @@ class Account(stellarAccount):
 class Stellar(Client):
     network = fields.Enum(Network)
     address = fields.String()
-    secret = fields.String()
 
-    def _attr_updated(self, name, value):
-        """
-        update the address if a new secret is set
+    def secret_updated(self, value):
+        self.address = stellar_sdk.Keypair.from_secret(value).public_key
 
-        Args:
-            name (str): attribute name
-            value (any): the new value
-        """
-        super()._attr_updated(name, value)
-
-        if name == "secret":
-            self.address = stellar_sdk.Keypair.from_secret(value).public_key
+    secret = fields.String(on_update=secret_updated)
 
     def _get_horizon_server(self):
         return stellar_sdk.Server(horizon_url=_HORIZON_NETWORKS[self.network.value])

--- a/jumpscale/core/base/fields.py
+++ b/jumpscale/core/base/fields.py
@@ -73,10 +73,20 @@ class ValidationError(Exception):
 
 
 class Field:
-    def __init__(self, default=None, required=False, indexed=False, readonly=False, validators=None, **kwargs):
+    def __init__(
+        self,
+        default=None,
+        required=False,
+        indexed=False,
+        readonly=False,
+        validators=None,
+        stored=True,
+        on_update=None,
+        compute=None,
+        **kwargs,
+    ):
         """
         Base field for all field types, have some common options that can be used any other field type too.
-
 
         Args:
             default (any, optional): default value. Defaults to None.
@@ -84,6 +94,9 @@ class Field:
             indexed (bool, optional): indexed or not. Defaults to False.
             readonly (bool, optional): can only get the value. Defaults to False.
             validators (list of function, optional): a list of functions that takes a value and raises ValidationError if not valid. Defaults to None.
+            stored (bool, optional): if the fields should be stored or not, useful for computed fields. Defaults to True.
+            on_update (callable, optional): a callable that takes the instance and new value on field updates. Defaults to None.
+            compute (callable, optional): a callable that takes the instance and returns a computed value for this field. `on_update` won't be called in this case. Defaults to None.
         """
         self.default = default
         self.required = required
@@ -95,9 +108,9 @@ class Field:
         if self.validators is None:
             self.validators = []
 
-        # self.validate = Schema({
-
-        # })
+        self.stored = stored
+        self.on_update = on_update
+        self.compute = compute
 
     def validate(self, value):
         """
@@ -138,6 +151,14 @@ class Field:
             any: a primitive raw value
         """
         return value
+
+    @property
+    def trigger_updates(self):
+        return callable(self.on_update)
+
+    @property
+    def computed(self):
+        return callable(self.compute)
 
 
 class Typed(Field):

--- a/tests/core/base/test_factory.py
+++ b/tests/core/base/test_factory.py
@@ -24,7 +24,10 @@ class Wallet(Base):
 
 
 class RichWallet(Wallet):
-    amount = fields.Integer(default=10000000)
+    def amount_updated(self, new_value):
+        print("got a new amount!", new_value)
+
+    amount = fields.Integer(default=10000000, on_update=amount_updated)
 
 
 class Client(Base):
@@ -48,8 +51,9 @@ class TestBaseFactory(unittest.TestCase):
     def test_create_with_different_instances(self):
         cl = Client()
         w = cl.wallets.get("aa")
+        w.amount = 1000
         self.assertEqual(cl.wallets.count, 1)
-        self.assertEqual(w.amount, 10000000)
+        self.assertEqual(w.amount, 1000)
 
         addr1 = w.addresses.new("mine")
         addr1.x = 456

--- a/tests/core/base/test_fields_with_base.py
+++ b/tests/core/base/test_fields_with_base.py
@@ -12,10 +12,24 @@ class Permission(Base):
 
 class User(Base):
     id = fields.Integer()
+    first_name = fields.String(default="")
+    last_name = fields.String(default="")
     emails = fields.List(fields.String())
     permissions = fields.List(fields.Object(Permission))
     custom_config = fields.Typed(dict)
     rating = fields.Float()
+
+    def get_full_name(self):
+        name = self.first_name
+        if self.last_name:
+            name += " " + self.last_name
+        return name
+
+    def get_unique_name(self):
+        return self.full_name.replace(" ", "") + ".user"
+
+    full_name = fields.String(compute=get_full_name)
+    unique_name = fields.String(compute=get_unique_name)
 
 
 class Colors(enum.Enum):
@@ -88,3 +102,16 @@ class TestBaseWithFields(unittest.TestCase):
 
         data = user.to_dict()
         self.assertEqual(data["rating"], 11.2)
+
+    def test_computed_field(self):
+        u = User()
+        u.first_name = "ahmed"
+
+        self.assertEqual(u.full_name, u.first_name)
+        u.last_name = "mohamed"
+
+        full_name = f"{u.first_name} {u.last_name}"
+        self.assertEqual(u.full_name, full_name)
+
+        unique_name = f"{u.first_name}{u.last_name}.user"
+        self.assertEqual(u.unique_name, unique_name)

--- a/tests/core/base/test_stored_factory.py
+++ b/tests/core/base/test_stored_factory.py
@@ -29,12 +29,41 @@ class UserType(Enum):
     ADMIN = "admin"
 
 
+class Greeter:
+    def __init__(self, name):
+        self.name = name
+
+    def say(self):
+        print("hello", self.name)
+
+
 class User(Base):
     emails = fields.List(fields.String())
     permissions = fields.List(fields.Object(Permission))
     custom_config = fields.Typed(dict)
     type = fields.Enum(UserType)
     password = fields.Secret()
+
+    first_name = fields.String(default="")
+    last_name = fields.String(default="")
+
+    def get_full_name(self):
+        name = self.first_name
+        if self.last_name:
+            name += " " + self.last_name
+        return name
+
+    def get_unique_name(self):
+        return self.full_name.replace(" ", "") + ".user"
+
+    full_name = fields.String(compute=get_full_name)
+    unique_name = fields.String(compute=get_unique_name)
+
+    def get_my_greeter(self):
+        return Greeter(self.full_name)
+
+    my_greeter = fields.Typed(Greeter, stored=False, compute=get_my_greeter)
+    ahmed_greeter = fields.Typed(Greeter, stored=False, default=Greeter("ahmed"))
 
 
 class Client(Base):
@@ -139,6 +168,68 @@ class TestStoredFactory(unittest.TestCase):
         self.assertNotEqual(cl, ret_cl)
         user = ret_cl.users.get("admin")
         self.assertEqual(user.type, UserType.ADMIN)
+
+    def test_create_with_non_stored_fields(self):
+        cl = self.factory.get("test_enum")
+
+        # test saving
+        user = cl.users.get("admin")
+        user.first_name = "abdo"
+        user.last_name = "tester"
+        user.my_greeter.say()
+        user.ahmed_greeter.say()
+
+        with self.assertRaises(fields.ValidationError):
+            user.ahmed_greeter = ""
+
+        data = user.to_dict()
+
+        self.assertFalse("my_greeter" in data)
+        self.assertFalse("ahmed_greeter" in data)
+
+        user.save()
+        cl.save()
+        # reset-factory for now, need to always get from store
+        self.factory = StoredFactory(Client)
+        ret_cl = self.factory.get("test_enum")
+
+        self.assertNotEqual(cl, ret_cl)
+        user = ret_cl.users.get("admin")
+
+        data = user.to_dict()
+
+        self.assertFalse("my_greeter" in data)
+        self.assertFalse("ahmed_greeter" in data)
+
+    def test_create_with_computed_fields(self):
+        cl = self.factory.get("test_enum")
+
+        # test saving
+        user = cl.users.get("admin")
+        # default value, still
+        self.assertEqual(user.type, UserType.USER)
+
+        # now set and test if it's saved
+        user.first_name = "ahmed"
+
+        self.assertEqual(user.full_name, user.first_name)
+        user.last_name = "mohamed"
+
+        full_name = f"{user.first_name} {user.last_name}"
+        self.assertEqual(user.full_name, full_name)
+
+        unique_name = f"{user.first_name}{user.last_name}.user"
+        self.assertEqual(user.unique_name, unique_name)
+        user.save()
+        cl.save()
+        # reset-factory for now, need to always get from store
+        self.factory = StoredFactory(Client)
+        ret_cl = self.factory.get("test_enum")
+
+        self.assertNotEqual(cl, ret_cl)
+        user = ret_cl.users.get("admin")
+        self.assertEqual(user.full_name, full_name)
+        self.assertEqual(user.unique_name, unique_name)
 
     def tearDown(self):
         for name in self.factory.store.list_all():


### PR DESCRIPTION
Added:

- `on_update`: for single-field updates
- `compute`: for computed fields
- `stored`: to control if you need this fields to be stored or not

Updated the docs too [here](https://github.com/js-next/js-ng/blob/9557df05ba1ba938f8f4865e9367ecd5d10615ea/docs/wiki/baseclasses.md).