### PR TITLE
Requiring url argument on creating explorer client

### DIFF
--- a/jumpscale/clients/explorer/__init__.py
+++ b/jumpscale/clients/explorer/__init__.py
@@ -4,6 +4,18 @@ from jumpscale.core.config import get_config
 
 
 class explorerFactory(StoredFactory):
+    def new(self, name, url, *args, **kwargs):
+        kwargs['url'] = url
+        instance = super().new(name, *args, **kwargs)
+        instance.url = url
+        return instance
+
+    def get(self, name, url, *args, **kwargs):
+        instance = self.find(name)
+        if instance:
+            return instance
+        return self.new(name, url, *args, **kwargs)
+
     def get_default(self):
         return self.get("default", url=get_config()["threebot"]["explorer_url"])
 

--- a/jumpscale/clients/explorer/explorer.py
+++ b/jumpscale/clients/explorer/explorer.py
@@ -15,11 +15,9 @@ from jumpscale.core.base import fields
 class Explorer(Client):
     url = fields.String()
 
-    def __init__(self, **kwargs):
-
+    def __init__(self, url, **kwargs):
         super().__init__(**kwargs)
-        self.url = kwargs.get("url")
-
+        self.url = url
         self._session = requests.Session()
         self._session.hooks = dict(response=raise_for_status)
 

--- a/jumpscale/clients/explorer/explorer.py
+++ b/jumpscale/clients/explorer/explorer.py
@@ -15,9 +15,10 @@ from jumpscale.core.base import fields
 class Explorer(Client):
     url = fields.String()
 
-    def __init__(self, url, **kwargs):
+    def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.url = url
+        self.url = kwargs['url']
+
         self._session = requests.Session()
         self._session.hooks = dict(response=raise_for_status)
 


### PR DESCRIPTION
Fixes https://github.com/js-next/js-ng/issues/277.
The explorer url was None because it was not provided and it was not a required argument so, it should be a required argument on explorer client creation